### PR TITLE
refactor: refine styles for professional touch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/index.html
+++ b/index.html
@@ -7,6 +7,9 @@
   <meta name="description" content="Especialistas en prompts y algoritmos para optimizar tu IA. Diseñamos prompts de alto rendimiento y modelos a medida para potenciar tus casos de uso con IA generativa." />
   <meta name="theme-color" content="#ffffff" />
   <link rel="icon" href="todoprompt-logo.png" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="styles.css" />
 </head>
 <body>

--- a/styles.css
+++ b/styles.css
@@ -1,8 +1,8 @@
 :root{
   --accent:#ef4444; /* rojo logo */
-  --txt: var(--accent); /* todo el texto en rojo */
+  --txt:#1f2937; /* texto oscuro para mejor legibilidad */
   --bg:#ffffff;
-  --muted:#b91c1c; /* rojo más oscuro para contraste sutil */
+  --muted:#6b7280; /* gris suave para textos secundarios */
   --radius:18px;
   --shadow:0 10px 30px rgba(0,0,0,.06);
 }
@@ -10,7 +10,7 @@
 *{box-sizing:border-box}
 html,body{margin:0;padding:0;scroll-behavior:smooth}
 body{
-  font:16px/1.55 system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Cantarell,'Helvetica Neue',Arial,sans-serif;
+  font:16px/1.55 'Inter',system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Cantarell,'Helvetica Neue',Arial,sans-serif;
   color:var(--txt); background:var(--bg);
 }
 .container{max-width:960px;margin:0 auto;padding:0 20px}
@@ -22,8 +22,9 @@ h1{margin:0; font-size:clamp(1.6rem,3.8vw,2.4rem); line-height:1.15}
 
 .card{
   background:#fff; border:1px solid #f1f1f1; border-radius:var(--radius);
-  box-shadow:var(--shadow); overflow:hidden;
+  box-shadow:var(--shadow); overflow:hidden; transition:transform .3s ease, box-shadow .3s ease;
 }
+.card:hover{transform:translateY(-4px); box-shadow:0 14px 40px rgba(0,0,0,.08)}
 .card-media{padding:18px; display:grid; place-items:center; background:#fff}
 .card-media img{width:min(360px, 90%); height:auto; object-fit:contain; transform:scale(.92); transition:transform .4s ease}
 .card:hover .card-media img{transform:scale(.96)}
@@ -33,14 +34,14 @@ h1{margin:0; font-size:clamp(1.6rem,3.8vw,2.4rem); line-height:1.15}
 .card-foot{display:flex; align-items:center; justify-content:space-between; gap:12px; flex-wrap:wrap}
 .price{font-weight:800; font-size:1.1rem}
 
-.btn{
+.btn{ 
   cursor:pointer; border-radius:14px; padding:.75rem 1rem; font-weight:800; text-decoration:none; display:inline-block;
   transition:transform .2s ease, box-shadow .2s ease, opacity .2s ease, background .2s ease, color .2s ease;
 }
 .btn-primary{background:var(--accent); color:#fff; box-shadow:var(--shadow)}
 .btn-primary:hover{transform:translateY(-2px)}
 .btn-outline{background:transparent; color:var(--accent); border:2px solid var(--accent)}
-.btn-outline:hover{transform:translateY(-2px)}
+.btn-outline:hover{transform:translateY(-2px); background:var(--accent); color:#fff}
 
 .contact{display:grid; gap:12px; justify-items:center; text-align:center; padding:28px 0 36px}
 .contact-line{margin:0; font-weight:700}


### PR DESCRIPTION
## Summary
- use Inter font and neutral colors for cleaner look
- add card hover and button hover enhancements
- ignore node_modules and build output

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: No inputs were found in config file `/workspace/Todoprompt/tsconfig.json`)*

------
https://chatgpt.com/codex/tasks/task_e_68a87d4efe4c8330aa16b26561c4453f